### PR TITLE
Wrong module title appended when adding module related columns

### DIFF
--- a/components/columns/usermodactions/plugin.class.php
+++ b/components/columns/usermodactions/plugin.class.php
@@ -34,13 +34,14 @@ class plugin_usermodactions extends plugin_base{
 	}
 	
 	function summary($data){
+		global $DB;
 		// should be a better way to do this
-		/*if($cm = $DB->get_record('course_modules',array('id' => $data->cmid))){
+		if($cm = $DB->get_record('course_modules',array('id' => $data->cmid))){
 			$modname = $DB->get_field('modules','name',array('id' => $cm->module));
-			if($name = $DB->get_field("$modname",'name',array('id' => $data->cmid))){
+			if($name = $DB->get_field("$modname",'name',array('id' => $cm->instance))){
 				return $data->columname.' ('.$name.')';
 			}
-		}*/		
+		}
 		
 		return $data->columname;
 	}

--- a/components/columns/usermodoutline/plugin.class.php
+++ b/components/columns/usermodoutline/plugin.class.php
@@ -34,14 +34,14 @@ class plugin_usermodoutline extends plugin_base{
 	}
 	
 	function summary($data){
-		/*global $DB;
+		global $DB;
 		// should be a better way to do this
 		if($cm = $DB->get_record('course_modules',array('id' => $data->cmid))){
 			$modname = $DB->get_field('modules','name',array('id' => $cm->module));
-			if($name = $DB->get_field("$modname",'name',array('id' => $data->cmid))){
+			if($name = $DB->get_field("$modname",'name',array('id' => $cm->instance))){
 				return $data->columname.' ('.$name.')';
 			}
-		}*/		
+		}		
 		
 		return $data->columname;
 	}

--- a/components/columns/usermodoutline/plugin.class.php
+++ b/components/columns/usermodoutline/plugin.class.php
@@ -34,14 +34,14 @@ class plugin_usermodoutline extends plugin_base{
 	}
 	
 	function summary($data){
-		global $DB;
+		/*global $DB;
 		// should be a better way to do this
 		if($cm = $DB->get_record('course_modules',array('id' => $data->cmid))){
 			$modname = $DB->get_field('modules','name',array('id' => $cm->module));
 			if($name = $DB->get_field("$modname",'name',array('id' => $data->cmid))){
 				return $data->columname.' ('.$name.')';
 			}
-		}		
+		}*/		
 		
 		return $data->columname;
 	}


### PR DESCRIPTION
Fixed the wrong module title being automatically appended to the column name when adding usermodactions and usermodoutline columns. The 'instance' field in mdl_course_modules acts as a foreign key for each of the respective module type tables e.g. mdl_scorm
