### PR TITLE
Enable reports to be run on the remote db with per report settings

### DIFF
--- a/db/upgrade.php
+++ b/db/upgrade.php
@@ -64,5 +64,16 @@ function xmldb_block_configurable_reports_upgrade($oldversion) {
         upgrade_plugin_savepoint(true, 2011040106, 'block', 'configurable_reports');
     }
 
+    if ($oldversion < 2011040115) {
+
+        $table = new xmldb_table('block_configurable_reports');
+
+        $field = new xmldb_field('remote', XMLDB_TYPE_INTEGER, '1', XMLDB_UNSIGNED, null, null, '0', null);
+        if (!$dbman->field_exists($table, $field)) {
+            $dbman->add_field($table, $field);
+        }
+        upgrade_plugin_savepoint(true, 2011040115, 'block', 'configurable_reports');
+    }
+
     return true;
 }

--- a/editreport.php
+++ b/editreport.php
@@ -197,6 +197,10 @@
 			$data->jsordering = 0;
 		}
 
+   		if(!isset($data->remote)) {
+			$data->remote = 0;
+		}
+
 		if(empty($report)){
 			$data->ownerid = $USER->id;
 			$data->courseid = $courseid;

--- a/editreport_form.php
+++ b/editreport_form.php
@@ -77,6 +77,10 @@ class report_edit_form extends moodleform {
         $mform->setDefault('cron',0);
         $mform->disabledIf('cron', 'type', 'neq', 'sql');
 
+        $mform->addElement('checkbox','remote',get_string('remote','block_configurable_reports'),get_string('remotedescription','block_configurable_reports'));
+        $mform->addHelpButton('remote','remote', 'block_configurable_reports');
+        $mform->setDefault('remote',0);
+
         $mform->addElement('header', 'exportoptions', get_string('exportoptions', 'block_configurable_reports'));
         $options = cr_get_export_plugins();
 

--- a/lang/en/block_configurable_reports.php
+++ b/lang/en/block_configurable_reports.php
@@ -52,6 +52,9 @@ $string['jsordering'] = 'JavaScript Ordering';
 $string['cron'] = 'Auto run daily';
 $string['crondescription'] = 'Schedule this query to run each day (At night)';
 $string['cron_help'] = 'Schedule this query to run each day (At night)';
+$string['remote'] = 'Run on remote db';
+$string['remotedescription'] = 'Do you want to run this query on the remote db';
+$string['remote_help'] = 'Do you want to run this query on the remote db';
 $string['setcourseid'] = 'Set courseid';
 
 // Columns

--- a/report.class.php
+++ b/report.class.php
@@ -54,7 +54,7 @@
         $remotedbuser = get_config('block_configurable_reports', 'dbuser');
         $remotedbpass = get_config('block_configurable_reports', 'dbpass');
 
-        if (!empty($remotedbhost) and !empty($remotedbname) and !empty($remotedbuser) and !empty($remotedbpass) ) {
+        if (!empty($remotedbhost) and !empty($remotedbname) and !empty($remotedbuser) and !empty($remotedbpass) and $this->config->remote) {
             $db_class = get_class($DB);
             $remotedb = new $db_class();
             $remotedb->connect($remotedbhost, $remotedbuser, $remotedbpass, $remotedbname, $CFG->prefix);

--- a/reports/sql/report.class.php
+++ b/reports/sql/report.class.php
@@ -63,33 +63,10 @@ class report_sql extends report_base {
 
 		$sql = preg_replace('/\bprefix_(?=\w+)/i', $CFG->prefix, $sql);
 
-        // Use a custom $DB (and not current system's $DB)
-        // todo: major security issue
-        $remotedbhost = get_config('block_configurable_reports','dbhost');
-        if (empty($remotedbhost)) {
-            $remotedbhost = $CFG->dbhost;
-        }
-        $remotedbname = get_config('block_configurable_reports','dbname');
-        if (empty($remotedbname)) {
-            $remotedbname = $CFG->dbname;
-        }
-        $remotedbuser = get_config('block_configurable_reports','dbuser');
-        if (empty($remotedbuser)) {
-            $remotedbuser = $CFG->dbuser;
-        }
-        $remotedbpass = get_config('block_configurable_reports','dbpass');
-        if (empty($remotedbpass)) {
-            $remotedbpass = $CFG->dbpass;
-        }
-
         $reportlimit = get_config('block_configurable_reports','reportlimit');
         if (empty($reportlimit) or $reportlimit == '0') {
                 $reportlimit = REPORT_CUSTOMSQL_MAX_RECORDS;
         }
-
-        $db_class = get_class($DB);
-        $remotedb = new $db_class();
-        $remotedb->connect($remotedbhost, $remotedbuser, $remotedbpass, $remotedbname, $CFG->prefix);
 
         $starttime = microtime(true);
 

--- a/version.php
+++ b/version.php
@@ -30,7 +30,7 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version = 2011040114;  // Plugin version.
+$plugin->version = 2011040115;  // Plugin version.
 $plugin->requires = 2011120500; // require Moodle version (2.2).
 $plugin->maturity = MATURITY_STABLE;
 $plugin->release = '2.3.3';


### PR DESCRIPTION
This pull request is for Issue #26 

New table column is added to track if the report is meant to be on the local or remote database. Also I removed the DB connection from the SQL report class as I wasn't sure if it was meant to be referenced twice. It looks like it should take the parent report.class.php settings, or at least be configured the same way.

Let me know if any changes need to be made.
