### PR TITLE
Fixed wrong selected item on some filters

### DIFF
--- a/components/filters/fcoursefield/plugin.class.php
+++ b/components/filters/fcoursefield/plugin.class.php
@@ -84,7 +84,7 @@ class plugin_fcoursefield extends plugin_base{
 		}
 
 		$mform->addElement('select', 'filter_fcoursefield_'.$data->field, get_string($data->field), $filteroptions);
-		$mform->setType('filter_courses', PARAM_INT);
+		$mform->setType('filter_courses', PARAM_BASE64);
 
 	}
 }

--- a/components/filters/fuserfield/plugin.class.php
+++ b/components/filters/fuserfield/plugin.class.php
@@ -157,6 +157,6 @@ class plugin_fuserfield extends plugin_base{
 		}
 
 		$mform->addElement('select', 'filter_fuserfield_'.$data->field, $selectname, $filteroptions);
-		$mform->setType('filter_fuserfield_'.$data->field, PARAM_INT);
+		$mform->setType('filter_fuserfield_'.$data->field, PARAM_BASE64);
 	}
 }


### PR DESCRIPTION
User field and course field filters clean the form data with PARAM_INT
instead of PARAM_BASE64, and the selected item is lost.
