### PR TITLE
Move github info text to the right setting

### DIFF
--- a/lang/en/block_configurable_reports.php
+++ b/lang/en/block_configurable_reports.php
@@ -419,14 +419,14 @@ $string['email_message'] = 'Message';
 $string['email_send'] = 'Send';
 
 $string['sqlsecurity'] = 'SQL Security';
-$string['sqlsecurityinfo'] = 'Disable for executing SQL queries with statements for inserting data (GitHub account owner + slash + repository name)';
+$string['sqlsecurityinfo'] = 'Disable for executing SQL queries with statements for inserting data';
 
 $string['global'] = 'Global report';
 $string['enableglobal'] = 'This is a global report (accesible from any course)';
 $string['global_help'] = 'Global report can be accessed from any course in the platform just appending &courseid=MY_COURSE_ID in the report URL';
 
 $string['crrepository'] = 'Reports repository';
-$string['crrepositoryinfo'] = 'Remote shared repository with sample reports fully functional';
+$string['crrepositoryinfo'] = 'Remote shared repository with sample reports fully functional (Name of GitHub account owner + slash + repository name)';
 $string['importfromrepository'] = 'Import report from repository';
 $string['repository'] = 'Reports repository';
 $string['repository_help'] = 'You can import sample reports from a public shared repository.


### PR DESCRIPTION
The description for the 'SQL Security' option had some help text talking about github usernames (http://ctrlv.in/564633)
I've moved that to the 'Reports repository' setting below where it was probably supposed to be (http://ctrlv.in/564635)
