### PR TITLE
Remove some bad characters from previous commit. Causes PHP errors.

### DIFF
--- a/components/plot/bar/graph.php
+++ b/components/plot/bar/graph.php
@@ -15,7 +15,7 @@
 // You should have received a copy of the GNU General Public License
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
-/** Configurable Reports«
+/** Configurable Reports
   * A Moodle block for creating customizable reports
   * @package blocks
   * @author: Juan leyva <http://www.twitter.com/jleyvadelgado>
@@ -114,12 +114,12 @@
 				$font_path = $CFG->dirroot."/blocks/configurable_reports/lib/pChart2/Fonts";
                 $label_offset = $longest_label * ($font_size/2);
                 $min_label_offset = $padding + 100;
->--->--->--->---$max_label_offset = $height / 2 + $padding;
+                $max_label_offset = $height / 2 + $padding;
                 if ($label_offset < $min_label_offset) {
                     $label_offset = $min_label_offset;
                 } else if ($label_offset > $max_label_offset) {
->--->--->--->--->---$label_offset = $max_label_offset;>-
->--->--->--->---}
+                    $label_offset = $max_label_offset;
+                }
 				$legend_offset = ($longest_legend * ($font_size/2));
 				$max_legend_offset = $width / 3 + $padding;
 				if ($legend_offset > $max_legend_offset) {


### PR DESCRIPTION
looks like a previous commit added some invalid characters... it failed our internal PHP Lint check. Those characters are real dashes - not tabs so it's completely invalid PHP.
