### PR TITLE
FIX group mode not cut pie

### DIFF
--- a/report.class.php
+++ b/report.class.php
@@ -778,6 +778,11 @@
 		// Debug Mode.			
 		$debug = (!empty($CFG->debug) && $CFG->debug >= DEBUG_DEVELOPER && $CFG->debugdisplay);
 
+		// GROUP not work with cut pie.
+		if ($settings->group) {
+            return $finalreport;
+        }
+
 		// Limit to cut off categories.
 		$limit = 0;
 		if (!empty($settings->limitcategories)) {


### PR DESCRIPTION
ADD check if GROUP mode is selected in PIE Graph in order to not apply limit categories in PIE graph.
