### PR TITLE
Fix css regression - which left align input fields in RTL mode.

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -22,7 +22,8 @@
 
 /* Left align Setting INPUT TEXT boxes
 */
-.dir-rtl .settingsform input[type=text], .dir-rtl .settingsform input[type=password] {text-align: left;direction: ltr;}
+#page-admin-setting-blocksettingconfigurable_reports.dir-rtl .settingsform input[type=text],
+#page-admin-setting-blocksettingconfigurable_reports.dir-rtl .settingsform input[type=password] {text-align: left;direction: ltr;}
 
 /* Table usability & UI fixes
 */


### PR DESCRIPTION
This is a regression I introduced at some point. and just now came across it on one of the sites I manage.
Which affects all the Form's settings input fields in RTL mode.

Please update.
