### PR TITLE
CONTRIB-5493: blocks_configurable_reports: If system context do not check is_enrolled

### DIFF
--- a/components/permissions/usersincoursereport/plugin.class.php
+++ b/components/permissions/usersincoursereport/plugin.class.php
@@ -40,6 +40,11 @@ class plugin_usersincoursereport extends plugin_base{
 	function execute($userid, $context, $data){
 		global $DB, $CFG;
 		
+		// Everyone should be enrolled at the system level.
+		if($context == context_system::instance()) {
+			return true;
+		}
+
 		return is_enrolled($context, $userid);
 
 	}


### PR DESCRIPTION
If a configurable report is set up on the site home page with the permission check of "Any user in the current report course" and a student access this page a fatal error is thrown:

Coding error detected, it must be fixed by a programmer: Context does not belong to any course.

This change alters the permission to check if the context is the site home context and if so return true as everyone is enrolled on the site home page.
