### PR TITLE
adding composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,17 @@
+{
+    "name": "jleyva/moodle-block_configurablereports",
+    "type": "moodle-block",
+    "description": "This block is a Moodle custom reports builder. You can create custom reports without SQL knowledge. It's a tool suitable for admins or teachers.",
+    "homepage": "https://moodle.org/plugins/view.php?plugin=block_configurable_reports",
+    "license": "GPL-3.0+",
+    "require": {
+        "composer/installers": "*"
+    },
+    "extra": {
+        "installer-name": "configurable_reports"
+    },
+    "support": {
+        "issues": "http://tracker.moodle.org/browse/CONTRIB/component/10753",
+        "source": "https://github.com/jleyva/moodle-block_configurablereports/"
+    }
+}


### PR DESCRIPTION
Hello,

this adds the composer.json file so people can deploy your plugin
using the composer tool (https://getcomposer.org/).
If you have any questions, please take a look at the following links:

https://moodle.org/mod/forum/discuss.php?d=275466
https://tracker.moodle.org/browse/MDL-48114
https://moodle.org/mod/forum/discuss.php?d=312215

I've made some pull requests to plugins that I use and like
and that have their source on github and until this point
11 plugins have merged, 18 are pending (including this one)
and only 1 delayed until a definitive position from Moodle HQ.

Kind regards,
Daniel
