### PR TITLE
blocks_configurable_reports: Fix warning when creating a bar graph

### DIFF
--- a/components/plot/bar/form.php
+++ b/components/plot/bar/form.php
@@ -97,12 +97,14 @@ class bar_form extends moodleform {
 			get_string('width','block_configurable_reports')
 		);
 		$mform->setDefault("width",900);
+		$mform->setType("width", PARAM_INT);
 		$mform->addElement(
 			'text',
 			'height',
 			get_string('height','block_configurable_reports')
 		);
 		$mform->setDefault("height",500);
+		$mform->setType("height", PARAM_INT);
 		
         /* Shouldn't use these without a way to automatically
          * calculate colors for the text and bars that contrast

--- a/lang/en/block_configurable_reports.php
+++ b/lang/en/block_configurable_reports.php
@@ -288,6 +288,7 @@ $string['yaxis'] = 'Y Axis';
 $string['serieid'] = 'Serie column';
 $string['groupseries'] = 'Group series';
 $string['linesummary'] = 'A line graph with multiple series of data';
+$string['xandynotequal'] = 'X and Y axis need to be different';
 
 $string['coursestats'] = 'Course stats';
 $string['statstotalenrolments'] = 'Total enrolments';


### PR DESCRIPTION
This fixes the debugging warning shown:

Debugging: Did you remember to call setType() for 'width'? Defaulting to PARAM_RAW cleaning. in ./lib/formslib.php on line 1332.
Debugging: Did you remember to call setType() for 'height'? Defaulting to PARAM_RAW cleaning. in ./lib/formslib.php on line 1332.
