### PR TITLE
Update locallib.php

### DIFF
--- a/locallib.php
+++ b/locallib.php
@@ -34,7 +34,7 @@ function cr_print_js_function() {
             tmpw.document.open();
             tmpw.document.write('<html><body>');
             tmpw.document.write(cdiv.innerHTML);
-            tmpw.document.write('</body></html>');
+            tmpw.document.write('</'+'body></html>');
             tmpw.document.close();
             tmpw.print();
             tmpw.close();


### PR DESCRIPTION
We made this minor change to get around a conflict with New Relic's PHP Agent/JS beacon that looks for the closing tag. Without this fix, the JS conflict causes a fatal error disabling the print functionality. I realize this isn't a problem with this plugin per se, but I thought it might be helpful to other that are using New Relic or some other software that injects scripts based on finding the tag.