### PR TITLE
Delay the print call.

### DIFF
--- a/locallib.php
+++ b/locallib.php
@@ -36,8 +36,10 @@ function cr_print_js_function() {
             tmpw.document.write(cdiv.innerHTML);
             tmpw.document.write('</'+'body></html>');
             tmpw.document.close();
-            tmpw.print();
-            tmpw.close();
+            setTimeout(function() {
+                tmpw.print();
+                tmpw.close();
+            }, 100);
         }
     </script>
 <?php


### PR DESCRIPTION
This fixes an issue in Chrome where the page is blank when the print() call is called.