### PR TITLE
Please update locallib.php with a greater delay on the print call.

### DIFF
--- a/locallib.php
+++ b/locallib.php
@@ -39,7 +39,7 @@ function cr_print_js_function() {
             setTimeout(function() {
                 tmpw.print();
                 tmpw.close();
-            }, 100);
+            }, 1000);
         }
     </script>
 <?php


### PR DESCRIPTION
This fixes an issue we previously had where chrome does not fully render the content before the print dialog is opened. Delaying to 1000ms seems like a safer value.