### PR TITLE
Fix dbschema mismatch

### DIFF
--- a/db/install.xml
+++ b/db/install.xml
@@ -18,8 +18,8 @@
         <FIELD NAME="components" TYPE="text" NOTNULL="false" SEQUENCE="false"/>
         <FIELD NAME="export" TYPE="char" LENGTH="255" NOTNULL="false" SEQUENCE="false"/>
         <FIELD NAME="jsordering" TYPE="int" LENGTH="4" NOTNULL="false" SEQUENCE="false"/>
-        <FIELD NAME="global" TYPE="int" LENGTH="4" NOTNULL="false" SEQUENCE="false"/>
-        <FIELD NAME="lastexecutiontime" TYPE="int" LENGTH="10" NOTNULL="false" SEQUENCE="false" COMMENT="Time this report took to run last time it was executed, in milliseconds."/>
+        <FIELD NAME="global" TYPE="int" LENGTH="4" NOTNULL="true" DEFAULT="0" SEQUENCE="false"/>
+        <FIELD NAME="lastexecutiontime" TYPE="int" LENGTH="10" NOTNULL="true" DEFAULT="0" SEQUENCE="false" COMMENT="Time this report took to run last time it was executed, in milliseconds."/>
         <FIELD NAME="cron" TYPE="int" LENGTH="4" NOTNULL="true" DEFAULT="0" SEQUENCE="false" COMMENT="Should we run this query on regular CRON"/>
         <FIELD NAME="remote" TYPE="int" LENGTH="1" NOTNULL="false" DEFAULT="0" SEQUENCE="false"/>
       </FIELDS>

--- a/db/upgrade.php
+++ b/db/upgrade.php
@@ -96,5 +96,31 @@ function xmldb_block_configurable_reports_upgrade($oldversion) {
 
         upgrade_plugin_savepoint(true, 2019020600, 'block', 'configurable_reports');
     }
+
+    if ($oldversion < 2019062000) {
+
+        $table = new xmldb_table('block_configurable_reports');
+
+        // Make sure these fields match install.xml.
+        $field = new xmldb_field('global', XMLDB_TYPE_INTEGER, '4', XMLDB_UNSIGNED, XMLDB_NOTNULL, null, '0', null);
+        if (!$dbman->field_exists($table, $field)) {
+            $dbman->change_field_default($table, $field);
+            $dbman->change_field_notnull($table, $field);
+        }
+
+        $field = new xmldb_field('lastexecutiontime', XMLDB_TYPE_INTEGER, '10', XMLDB_UNSIGNED, XMLDB_NOTNULL, null, '0', null);
+        if (!$dbman->field_exists($table, $field)) {
+            $dbman->change_field_default($table, $field);
+            $dbman->change_field_notnull($table, $field);
+        }
+
+        $field = new xmldb_field('cron', XMLDB_TYPE_INTEGER, '4', XMLDB_UNSIGNED, XMLDB_NOTNULL, null, '0', null);
+        if (!$dbman->field_exists($table, $field)) {
+            $dbman->change_field_precision($table, $field);
+            $dbman->change_field_notnull($table, $field);
+        }
+        upgrade_plugin_savepoint(true, 2019062000, 'block', 'configurable_reports');
+    }
+
     return true;
 }

--- a/version.php
+++ b/version.php
@@ -29,7 +29,7 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version = 2019060300;  // Plugin version.
+$plugin->version = 2019062000;  // Plugin version.
 $plugin->requires = 2015111600; // require Moodle version (3.0).
 $plugin->maturity = MATURITY_STABLE;
 $plugin->release = '3.7.0';


### PR DESCRIPTION
Hi Juan,

I have came across some mismatch in the DB schema, would you please have a loo:

**'global' column**
It has no default value in install.xml: https://github.com/jleyva/moodle-block_configurablereports/blob/MOODLE_36_STABLE/db/install.xml#L21
The default value is '0' in upgrade.php: https://github.com/jleyva/moodle-block_configurablereports/blob/MOODLE_36_STABLE/db/upgrade.php#L48 

**lastexecutiontime**"
It has no default value in install.xml: https://github.com/jleyva/moodle-block_configurablereports/blob/MOODLE_36_STABLE/db/install.xml#L22
The default value is '0' in upgrade.php: https://github.com/jleyva/moodle-block_configurablereports/blob/MOODLE_36_STABLE/db/upgrade.php#L53

**'cron':**
It is NOT NULL in install.xml: https://github.com/jleyva/moodle-block_configurablereports/blob/MOODLE_36_STABLE/db/install.xml#L23
NULL is allowed in upgrade.php: https://github.com/jleyva/moodle-block_configurablereports/blob/MOODLE_36_STABLE/db/upgrade.php#L58

Thanks

