### PR TITLE
Fix template array error

### DIFF
--- a/report.class.php
+++ b/report.class.php
@@ -667,7 +667,12 @@ class report_base {
             }
 
             foreach ($this->finalreport->table->data as $r) {
-                $recordtext = $recordtpl;
+                if (is_array($recordtpl)) {
+                    $recordtext = $recordtpl['text'];
+                } else {
+                    $recordtext = $recordtpl;
+                }
+                
                 foreach ($this->finalreport->table->head as $key => $c) {
                     $recordtext = str_ireplace("[[$c]]", $r[$key], $recordtext);
                 }


### PR DESCRIPTION
When the template form is submitted, a 'format' variable is saved along with the actual data for the header, footer, and record. This causes an 'array to string conversion' error when attempting to replace and render the record data. Commit d572df1 fixed this for the header and footer, but not the records that are iterated through, resulting in the body of the report reading 'ArrayArrayArray' when using a template.

This fix uses the same approach as commit d572df1, by checking to see if the record value ($recordtpl) is an array; if it is, we use the 'text' value instead of the record value directly.