### PR TITLE
Fix issues with bar graphs not being rendered

### DIFF
--- a/components/plot/bar/form.php
+++ b/components/plot/bar/form.php
@@ -37,9 +37,12 @@ class bar_form extends moodleform {
             }
 
             $columns = $components['columns']['elements'];
+            $i = 0;
             foreach ($columns as $c) {
                 if (!empty($c['summary'])) {
-                    $options[] = $c['summary'];
+                    $key = "$i," . $c['summary'];
+                    $options[$key] = str_replace('_', ' ', $c['summary']);
+                    $i++;
                 }
             }
         } else {

--- a/components/plot/bar/graph.php
+++ b/components/plot/bar/graph.php
@@ -79,9 +79,6 @@ if (!$reportclass->check_permissions($USER->id, $context)) {
 
             // Dataset definition.
             $dataset = new pData();
-            $f = fopen("/tmp/bar.series-pre", "w");
-            fwrite($f, print_r($series, true));
-            fclose($f);
             $labels = array_shift($series);
 
             // Invert/Reverse Hebrew labels so it can be rendered using PHP imagettftext()
@@ -94,9 +91,7 @@ if (!$reportclass->check_permissions($USER->id, $context)) {
             }
             $dataset->addPoints($invertedlabels, "Labels");
             $dataset->setAbscissa("Labels");
-            $f = fopen("/tmp/bar.series", "w");
-            fwrite($f, print_r($series, true));
-            fclose($f);
+
             $longestlegend = 0;
             foreach ($series as $name => $valueset) {
                 $legendlen = strlen($name);


### PR DESCRIPTION
Non SQL reports trying to use bar graphs didn't have the write options configured in the form. This caused the below to fail on L45 of plugin.class.php and causes the undefined offset issues in #101 

```
list($labelidx, $labelname) = explode(",", $data->label_field);
```

There were also fopen/fwrite commands that weren't being used and also caused PHP errors due to the hard coded `/tmp` directory.

If they are needed for future development or debugging they need to be at least updated to `$CFG->tempdir . /tmp/...` but should also have a `mkdir` at the beginning to create a folder for `/configurable_reports/`.