### PR TITLE
fix STARTTIME and ENDTIME variable substitution

### DIFF
--- a/components/filters/startendtime/plugin.class.php
+++ b/components/filters/startendtime/plugin.class.php
@@ -81,8 +81,8 @@ class plugin_startendtime extends plugin_base {
             $finalelements = str_replace('%%FILTER_ENDTIME:'.$output[1].'%%', $replace, $finalelements);
         }
 
-        $finalelements = str_replace('%STARTTIME%%', $filterstarttime, $finalelements);
-        $finalelements = str_replace('%ENDTIME%%', $filterendtime, $finalelements);
+        $finalelements = str_replace('%%STARTTIME%%', $filterstarttime, $finalelements);
+        $finalelements = str_replace('%%ENDTIME%%', $filterendtime, $finalelements);
 
         return $finalelements;
     }


### PR DESCRIPTION
Currently the string to be replaced for STARTTIME and ENDTIME contains one '%' instead of two '%%'. This causes an error in moodle when trying to use these variables. This commit fixes the problem by using the proper replacement string.