### PR TITLE
raise name input element's maxlength to 128 (eDaktik: #4139)

### DIFF
--- a/editreport_form.php
+++ b/editreport_form.php
@@ -39,7 +39,7 @@ class report_edit_form extends moodleform {
 
         $mform->addElement('header', 'general', get_string('general', 'form'));
 
-        $mform->addElement('text', 'name', get_string('name'), array('maxlength' => 60, 'size' => 58));
+        $mform->addElement('text', 'name', get_string('name'), array('maxlength' => 128, 'size' => 58));
         if (!empty($CFG->formatstringstriptags)) {
             $mform->setType('name', PARAM_TEXT);
         } else {


### PR DESCRIPTION
(this PR replaces the outdated PR #108)

This pull request raises the max length of report names to 128 characters as defined in database layout (install.xml).
Unfortunately due to certain circumstances my colleague (who left eDaktik in the meantime) seems to have deleted the fork including the code for PR #108.
So I'm starting a new PR to replace the old one, which is not editable by eDaktik anymore.
PR is small and based on current MOODLE_36_STABLE branch, so it should be mergeable without much conflicts.

To test the changes, I just created a report with a 128 characters long name:
`0abcdefghj1abcdefghj2abcdefghj3abcdefghj4abcdefghj5abcdefghj6abcdefghj7abcdefghj8abcdefghj9abcdefghj10abcdefgh11abcdefgh12abc128`

Best Regards,
Philipp