### PR TITLE
Convert pChart to be PHP7 compatible

### DIFF
--- a/lib/pChart/pCache.class
+++ b/lib/pChart/pCache.class
@@ -38,7 +38,7 @@
    var $CacheFolder = "Cache/";
 
    /* Create the pCache object */
-   function pCache($CacheFolder="Cache/")
+   function __construct($CacheFolder="Cache/")
     {
      $this->CacheFolder = $CacheFolder;
     }

--- a/lib/pChart/pChart.class
+++ b/lib/pChart/pChart.class
@@ -213,7 +213,7 @@
    var $MapID            = NULL;
 
    /* This function create the background picture */
-   function pChart($XSize,$YSize)
+   function __construct($XSize,$YSize)
     {
      $this->XSize   = $XSize;
      $this->YSize   = $YSize;

--- a/lib/pChart/pChart.class
+++ b/lib/pChart/pChart.class
@@ -298,7 +298,7 @@
          $buffer = fgets($handle, 4096);
          $buffer = str_replace(chr(10),"",$buffer);
          $buffer = str_replace(chr(13),"",$buffer);
-         $Values = split($Delimiter,$buffer);
+         $Values = explode($Delimiter,$buffer);
          if ( count($Values) == 3 )
           {
            $this->Palette[$ColorID]["R"] = $Values[0];
@@ -3384,7 +3384,7 @@
     {
      /* Strip HTML query strings */
      $Values   = $this->tmpFolder.$MapName;
-     $Value    = split("\?",$Values);
+     $Value    = explode("?",$Values);
      $FileName = $Value[0];
 
      if ( file_exists($FileName) )

--- a/lib/pChart/pData.class
+++ b/lib/pChart/pData.class
@@ -72,7 +72,7 @@
          $buffer = fgets($handle, 4096);
          $buffer = str_replace(chr(10),"",$buffer);
          $buffer = str_replace(chr(13),"",$buffer);
-         $Values = split($Delimiter,$buffer);
+         $Values = explode($Delimiter,$buffer);
 
          if ( $buffer != "" )
           {

--- a/lib/pChart/pData.class
+++ b/lib/pChart/pData.class
@@ -50,7 +50,7 @@
    var $Data;
    var $DataDescription;
 
-   function pData()
+   function __construct()
     {
      $this->Data                           = [];
      $this->DataDescription                = [];


### PR DESCRIPTION
For #148 

Change the PHP4 style constructors to be PHP7 compatible and also remove `split` to change it to be `explode` instead