### PR TITLE
Allow sql reporting to be restricted to specific usernames.

### DIFF
--- a/editcomp.php
+++ b/editcomp.php
@@ -67,9 +67,12 @@ if (!$hasreportscap && !has_capability('block/configurable_reports:manageownrepo
     print_error('badpermissions');
 }
 
-
 if (!$hasreportscap && $report->ownerid != $USER->id) {
     print_error('badpermissions');
+}
+
+if ($report->type == 'sql' && !block_configurable_reports_can_managesqlreports($context)) {
+    print_error('nosqlpermissions');
 }
 
 require_once($CFG->dirroot.'/blocks/configurable_reports/reports/'.$report->type.'/report.class.php');

--- a/editreport.php
+++ b/editreport.php
@@ -70,6 +70,10 @@ if ($id) {
     if (!$hasmanagereportcap && $report->ownerid != $USER->id) {
         print_error('badpermissions', 'block_configurable_reports');
     }
+    // Extra check.
+    if ($report->type == 'sql' && !block_configurable_reports_can_managesqlreports($context)) {
+        print_error('nosqlpermissions');
+    }
 
     $title = format_string($report->name);
 
@@ -221,7 +225,7 @@ if ($editform->is_cancelled()) {
         $data->components = '';
 
         // Extra check.
-        if ($data->type == 'sql' && !has_capability('block/configurable_reports:managesqlreports', $context)) {
+        if ($data->type == 'sql' && !block_configurable_reports_can_managesqlreports($context)) {
             print_error('nosqlpermissions');
         }
 

--- a/lang/en/block_configurable_reports.php
+++ b/lang/en/block_configurable_reports.php
@@ -461,7 +461,8 @@ $string['email_send'] = 'Send';
 
 $string['sqlsecurity'] = 'SQL Security';
 $string['sqlsecurityinfo'] = 'Disable for executing SQL queries with statements for inserting data';
-
+$string['allowedsqlusers'] = 'SQL report users';
+$string['allowedsqlusersinfo'] = 'If you wish to only allow certain admin users to manage sql reports, add a list of usernames separated by commas. They must also have the block/configurable_reports:managesqlreports capability.';
 $string['global'] = 'Global report';
 $string['enableglobal'] = 'This is a global report (accesible from any course)';
 $string['global_help'] = 'Global report can be accessed from any course in the platform just appending &courseid=MY_COURSE_ID in the report URL';

--- a/locallib.php
+++ b/locallib.php
@@ -190,7 +190,7 @@ function cr_get_report_plugins($courseid) {
 
     if ($plugins) {
         foreach ($plugins as $p) {
-            if ($p == 'sql' && !has_capability('block/configurable_reports:managesqlreports', $context)) {
+            if ($p == 'sql' && !block_configurable_reports_can_managesqlreports($context)) {
                 continue;
             }
             $pluginoptions[$p] = get_string('report_'.$p, 'block_configurable_reports');
@@ -569,4 +569,28 @@ function cr_logging_info() {
     }
 
     return array($uselegacyreader, $useinternalreader, $logtable);
+}
+
+/**
+ * Check if the current user is allowed to manage sql reports.
+ *
+ * @param $context
+ * @return bool
+ * @throws coding_exception
+ * @throws dml_exception
+ */
+function block_configurable_reports_can_managesqlreports($context) {
+    global $USER;
+    if (has_capability('block/configurable_reports:managesqlreports', $context)) {
+        $allowedusers = get_config('block_configurable_reports', 'allowedsqlusers');
+        if (!empty($allowedusers)) {
+            $allowedusers = explode(',', $allowedusers);
+            if (in_array($USER->username, $allowedusers)) {
+                return true;
+            }
+        } else {
+            return true;
+        }
+    }
+    return false;
 }

--- a/managereport.php
+++ b/managereport.php
@@ -134,30 +134,33 @@ if ($reports) {
         } else {
             $owner = get_string('deleted');
         }
-
-        $editcell = '';
-        $editcell .= '<a title="'.$stredit.'"  href="editreport.php?id='.$r->id.'">'.
-                     $OUTPUT->pix_icon('t/edit', $stredit).
-                     '</a>&nbsp;&nbsp;';
-        $editcell .= '<a title="'.$strdelete.'"  href="editreport.php?id='.$r->id.'&amp;delete=1&amp;sesskey='.$USER->sesskey.'">'.
-                     $OUTPUT->pix_icon('t/delete', $strdelete).
-                     '</a>&nbsp;&nbsp;';
-
-        if (!empty($r->visible)) {
-            $editcell .= '<a title="'.$strhide.'" href="editreport.php?id='.$r->id.'&amp;hide=1&amp;sesskey='.$USER->sesskey.'">'.
-                         $OUTPUT->pix_icon('t/hide', $strhide).
-                         '</a> ';
+        if ($r->type == 'sql' && !block_configurable_reports_can_managesqlreports($context)) {
+            $editcell = '';
         } else {
-            $editcell .= '<a title="'.$strshow.'" href="editreport.php?id='.$r->id.'&amp;show=1&amp;sesskey='.$USER->sesskey.'">'.
-                         $OUTPUT->pix_icon('t/show', $strshow).
-                         '</a> ';
+            $editcell = '<a title="'.$stredit.'"  href="editreport.php?id='.$r->id.'">'.
+                $OUTPUT->pix_icon('t/edit', $stredit).
+                '</a>&nbsp;&nbsp;';
+            $editcell .= '<a title="'.$strdelete.'"  href="editreport.php?id='.$r->id.'&amp;delete=1&amp;sesskey='.$USER->sesskey.'">'.
+                $OUTPUT->pix_icon('t/delete', $strdelete).
+                '</a>&nbsp;&nbsp;';
+
+            if (!empty($r->visible)) {
+                $editcell .= '<a title="'.$strhide.'" href="editreport.php?id='.$r->id.'&amp;hide=1&amp;sesskey='.$USER->sesskey.'">'.
+                    $OUTPUT->pix_icon('t/hide', $strhide).
+                    '</a> ';
+            } else {
+                $editcell .= '<a title="'.$strshow.'" href="editreport.php?id='.$r->id.'&amp;show=1&amp;sesskey='.$USER->sesskey.'">'.
+                    $OUTPUT->pix_icon('t/show', $strshow).
+                    '</a> ';
+            }
+            $editcell .= '<a title="'.$strcopy.'" href="editreport.php?id='.$r->id.'&amp;duplicate=1&amp;sesskey='.$USER->sesskey.'">'.
+                $OUTPUT->pix_icon('t/copy', $strcopy).
+                '</a>&nbsp;&nbsp;';
+            $editcell .= '<a title="'.$strexport.'" href="export.php?id='.$r->id.'&amp;sesskey='.$USER->sesskey.'">'.
+                $OUTPUT->pix_icon('t/backup', $strexport).
+                '</a>&nbsp;&nbsp;';
+
         }
-        $editcell .= '<a title="'.$strcopy.'" href="editreport.php?id='.$r->id.'&amp;duplicate=1&amp;sesskey='.$USER->sesskey.'">'.
-                     $OUTPUT->pix_icon('t/copy', $strcopy).
-                     '</a>&nbsp;&nbsp;';
-        $editcell .= '<a title="'.$strexport.'" href="export.php?id='.$r->id.'&amp;sesskey='.$USER->sesskey.'">'.
-                     $OUTPUT->pix_icon('t/backup', $strexport).
-                     '</a>&nbsp;&nbsp;';
 
         $download = '';
         $export = explode(',', $r->export);

--- a/settings.php
+++ b/settings.php
@@ -47,4 +47,7 @@ if ($ADMIN->fulltree) {
 
     $settings->add(new admin_setting_configtext('block_configurable_reports/reportlimit', get_string('reportlimit', 'block_configurable_reports'),
         get_string('reportlimitinfo', 'block_configurable_reports'), '5000', PARAM_INT, 6));
+
+    $settings->add(new admin_setting_configtext('block_configurable_reports/allowedsqlusers', get_string('allowedsqlusers', 'block_configurable_reports'),
+        get_string('allowedsqlusersinfo', 'block_configurable_reports'), '', PARAM_TEXT));
 }


### PR DESCRIPTION
This allows a site to install the configurable reports block and disable the ability to write manual sql reports when not all Moodle admins can be trusted to write and manage SQL reports - for example where the moodle admin is not the server admin.