### PR TITLE
CSV delimiter from Moodle Configuration closes #196

### DIFF
--- a/export/csv/export.php
+++ b/export/csv/export.php
@@ -47,7 +47,7 @@ function export_report($report) {
         }
     }
 
-    $csvexport = new csv_export_writer();
+    $csvexport = new csv_export_writer('cfg');
     $csvexport->set_filename($filename);
 
     foreach ($matrix as $ri => $col) {


### PR DESCRIPTION
closes #196

The CSV export does not set a delimiter when instantiating `csv_export_writer`. Hence the API assumes `comma`:

- https://bit.ly/3FQpKYu

- https://bit.ly/3sSzCxi

Here in Brazil, Excel "prefers" `semicolon`, and I propose that this instantiation set `cfg` as the delimiter.

If the setting is not present in the Moodle configuration file, the API will fall back to `comma`:

- https://bit.ly/3eME8F4