### PR TITLE
Let filters to be set before running reports

### DIFF
--- a/lang/en/block_configurable_reports.php
+++ b/lang/en/block_configurable_reports.php
@@ -54,6 +54,7 @@ $string['exportoptions'] = "Export options";
 $string['field'] = "Field";
 
 // Report form
+$string['applyfilters'] = "Apply filters to run the report";
 $string['typeofreport'] = "Type of report";
 $string['enablejsordering'] = "Enable JavaScript ordering";
 $string['enablejspagination'] = "Enable JavaScript Pagination";

--- a/report.class.php
+++ b/report.class.php
@@ -779,7 +779,11 @@ class report_base {
 
             $this->print_export_options();
         } else {
-            echo '<div class="centerpara">'.get_string('norecordsfound', 'block_configurable_reports').'</div>';
+            if (isset($this->filterform) && !$this->filterform->get_data()) {
+                echo '<div class="centerpara">'.get_string('applyfilters', 'block_configurable_reports').'</div>';
+            } else {
+                echo '<div class="centerpara">'.get_string('norecordsfound', 'block_configurable_reports').'</div>';
+            }
         }
 
         echo '<div class="centerpara"><br />';

--- a/reports/sql/report.class.php
+++ b/reports/sql/report.class.php
@@ -129,7 +129,7 @@ class report_sql extends report_base {
 
             $sql = $this->prepare_sql($sql);
 
-            if ($rs = $this->execute_query($sql)) {
+            if (isset($this->filterform) && $this->filterform->get_data() && $rs = $this->execute_query($sql)) {
                 foreach ($rs as $row) {
                     if (empty($finaltable)) {
                         foreach ($row as $colname => $value) {

--- a/viewreport.php
+++ b/viewreport.php
@@ -71,6 +71,7 @@ $PAGE->requires->jquery();
 $download = ($download && $format && strpos($report->export, $format.',') !== false) ? true : false;
 
 if ($download && $report->type == "sql") $reportclass->setForExport(true);
+$reportclass->check_filters_request();
 $reportclass->create_report();
 
 $action = (!empty($download)) ? 'download' : 'view';
@@ -78,7 +79,6 @@ cr_add_to_log($report->courseid, 'configurable_reports', $action, '/block/config
 
 // No download, build navigation header etc..
 if (!$download) {
-    $reportclass->check_filters_request();
     $reportname = format_string($report->name);
     $navlinks = array();
 


### PR DESCRIPTION
This would help to mitigate the issue #146 with heavy reports that are taking long to execute when filters are not set.

For instance, you have a report that scans log table or does heavy joins and you don't really want to run the report without filters as it would take ages to complete while with filters set it is pretty quick and good enough to be used.

Currently, users have to wait for the report to load with empty filters, then they set filters and run the report again.

The idea of this enhancement is to prevent the report from executing if filters are configured, but not set. When users access reports with added filters they can see _Apply filters to run the report_ message under the filter form. Then they can set the filters and click _Apply_ button to run the report.