### PR TITLE
Filter out deleted users from the select

### DIFF
--- a/components/filters/users/plugin.class.php
+++ b/components/filters/users/plugin.class.php
@@ -67,7 +67,7 @@ class plugin_users extends plugin_base {
 
             $userslist = $reportclass->elements_by_conditions($conditions);
         } else {
-            $userslist = array_keys($remotedb->get_records('user'));
+            $userslist = array_keys($remotedb->get_records('user',['deleted'=>0])); // Filter out deleted users from the select 
         }
 
         $usersoptions = array();


### PR DESCRIPTION
This tiny commit fixes a bug in Users filter, where deleted users are listed.