### PR TITLE
Fix preferred log reader obtaining

### DIFF
--- a/locallib.php
+++ b/locallib.php
@@ -557,12 +557,14 @@ function cr_logging_info() {
                 if ($readerpluginname == 'logstore_legacy') {
                     $uselegacyreader = true;
                     $logtable = 'log';
+                    break;
                 }
 
                 // If sql_internal_table_reader is preferred reader.
                 if ($reader instanceof \core\log\sql_internal_table_reader or $reader instanceof \core\log\sql_internal_reader) {
                     $useinternalreader = true;
                     $logtable = $reader->get_internal_log_table_name();
+                    break;
                 }
             }
         }


### PR DESCRIPTION
There is a minor bug in the `cr_logging_info()` function in `locallib.php`. If more than one log reader is enabled on a Moodle site, it will ignore the order priority, as the `foreach` that iterates through the readers doesn't stop once it obtains the first reader. In my proposed solution, it will `break` the `foreach` once it obtains the first log reader established in the configuration, be it the standard log, the legacy log, or whichever other log reader is preferred.

This bug can be easily reproduced if you have some courses with user activity and try to create a configurable report that calculates the time spent on a course. If the preferred log reader is the Standard Log, it will show 0 hours for every user, as it won't find any record of user activity on the mdl_log, which is the one that is consulting due to this bug.