### PR TITLE
FIX-226: Stop getting string from report_customsql plugin

### DIFF
--- a/components/customsql/form.php
+++ b/components/customsql/form.php
@@ -102,7 +102,7 @@ class customsql_form extends moodleform {
 
         } else if (strpos($sql, ';') !== false) {
             // Do not allow any semicolons.
-            $errors['querysql'] = get_string('nosemicolon', 'report_customsql');
+            $errors['querysql'] = get_string('nosemicolon', 'block_configurable_reports');
 
         } else if ($CFG->prefix != '' && preg_match('/\b' . $CFG->prefix . '\w+/i', $sql)) {
             // Make sure prefix is prefix_, not explicit.


### PR DESCRIPTION
This fixes an issue reported in #226 where block_configurable_report would display an "Invalid get_string() identifier: 'nosemicolon'" when saving an SQL query. 

This is only visible when debug is set to Developer mode and only happens if the report_customsql plugin is not also installed.