### PR TITLE
fix composer name in pchart2

### DIFF
--- a/lib/pChart2/composer.json
+++ b/lib/pChart2/composer.json
@@ -1,5 +1,5 @@
 {
-  "name": "bozhinov/pChart2.0-for-PHP7",
+  "name": "bozhinov/pchart2.0-for-php7",
   "description": "Fork of pChart 2.0 compatible with PHP 7",
   "Version": "1.3",
   "keywords": [


### PR DESCRIPTION
Composer naming convention says that the package names should be all lowercase, which is not the case for pghcart2. Violating this can throw errors in some more strict environments.

https://github.com/bozhinov/pChart2.0-for-PHP7/blob/master/composer.json

This just got fixed upstream, and rather than update to the latest version with various changes, I'm suggesting just also fixing up the name in here as well, that way there's no real code changes, but it also removes the composer error that can get thrown when names are not valid.