### PR TITLE
Replace print_error (method deprecated) everywhere in the code

### DIFF
--- a/block_configurable_reports.php
+++ b/block_configurable_reports.php
@@ -103,7 +103,7 @@ class block_configurable_reports extends block_list {
         $course = $DB->get_record('course', array('id' => $COURSE->id));
 
         if (!$course) {
-            print_error('coursedoesnotexists');
+            throw new \moodle_exception('coursedoesnotexists');
         }
 
         if ($course->id == SITEID) {

--- a/components/calcs/average/plugin.class.php
+++ b/components/calcs/average/plugin.class.php
@@ -39,7 +39,7 @@ class plugin_average extends plugin_base{
         if ($this->report->type != 'sql') {
             $components = cr_unserialize($this->report->components);
             if (!is_array($components) || empty($components['columns']['elements'])) {
-                print_error('nocolumns');
+                throw new \moodle_exception('nocolumns');
             }
 
             $columns = $components['columns']['elements'];

--- a/components/calcs/component.class.php
+++ b/components/calcs/component.class.php
@@ -39,7 +39,7 @@ class component_calcs extends component_base {
 
         if ($this->config->type != 'sql') {
             if (!is_array($components) || empty($components['columns']['elements'])) {
-                print_error('nocolumns');
+                throw new \moodle_exception('nocolumns');
             }
 
             $columns = $components['columns']['elements'];

--- a/components/calcs/max/plugin.class.php
+++ b/components/calcs/max/plugin.class.php
@@ -39,7 +39,7 @@ class plugin_max extends plugin_base{
         if ($this->report->type != 'sql') {
             $components = cr_unserialize($this->report->components);
             if (!is_array($components) || empty($components['columns']['elements'])) {
-                print_error('nocolumns');
+                throw new \moodle_exception('nocolumns');
             }
 
             $columns = $components['columns']['elements'];

--- a/components/calcs/min/plugin.class.php
+++ b/components/calcs/min/plugin.class.php
@@ -39,7 +39,7 @@ class plugin_min extends plugin_base{
         if ($this->report->type != 'sql') {
             $components = cr_unserialize($this->report->components);
             if (!is_array($components) || empty($components['columns']['elements'])) {
-                print_error('nocolumns');
+                throw new \moodle_exception('nocolumns');
             }
 
             $columns = $components['columns']['elements'];

--- a/components/calcs/percent/plugin.class.php
+++ b/components/calcs/percent/plugin.class.php
@@ -39,7 +39,7 @@ class plugin_percent extends plugin_base {
 		if ($this->report->type != 'sql') {
 			$components = cr_unserialize($this->report->components);
 			if (!is_array($components) || empty($components['columns']['elements'])) {
-				print_error('nocolumns');
+				throw new \moodle_exception('nocolumns');
 			}
 
 			$columns = $components['columns']['elements'];

--- a/components/calcs/sum/plugin.class.php
+++ b/components/calcs/sum/plugin.class.php
@@ -39,7 +39,7 @@ class plugin_sum extends plugin_base {
         if ($this->report->type != 'sql') {
             $components = cr_unserialize($this->report->components);
             if (!is_array($components) || empty($components['columns']['elements'])) {
-                print_error('nocolumns');
+                throw new \moodle_exception('nocolumns');
             }
 
             $columns = $components['columns']['elements'];

--- a/components/columns/reportcolumn/plugin.class.php
+++ b/components/columns/reportcolumn/plugin.class.php
@@ -125,7 +125,7 @@ class plugin_reportcolumn extends plugin_base {
         global $DB, $CFG;
 
         if (!$report = $DB->get_record('block_configurable_reports', array('id' => $data->reportid))) {
-            print_error('reportdoesnotexists', 'block_configurable_reports');
+            throw new \moodle_exception('reportdoesnotexists', 'block_configurable_reports');
         }
 
         require_once($CFG->dirroot.'/blocks/configurable_reports/report.class.php');

--- a/components/filters/fcoursefield/plugin.class.php
+++ b/components/filters/fcoursefield/plugin.class.php
@@ -66,7 +66,7 @@ class plugin_fcoursefield extends plugin_base {
         }
 
         if (!isset($coursecolumns[$data->field])) {
-            print_error('nosuchcolumn');
+            throw new \moodle_exception('nosuchcolumn');
         }
 
         $reportclassname = 'report_'.$this->report->type;

--- a/components/filters/fsearchuserfield/plugin.class.php
+++ b/components/filters/fsearchuserfield/plugin.class.php
@@ -110,7 +110,7 @@ class plugin_fsearchuserfield extends plugin_base{
         }
 
         if (!isset($usercolumns[$data->field])) {
-            print_error('nosuchcolumn');
+            throw new \moodle_exception('nosuchcolumn');
         }
 
         $reportclassname = 'report_'.$this->report->type;

--- a/components/filters/fuserfield/plugin.class.php
+++ b/components/filters/fuserfield/plugin.class.php
@@ -114,7 +114,7 @@ class plugin_fuserfield extends plugin_base {
         }
 
         if (!isset($usercolumns[$data->field])) {
-            print_error('nosuchcolumn');
+            throw new \moodle_exception('nosuchcolumn');
         }
 
         $reportclassname = 'report_'.$this->report->type;
@@ -175,7 +175,7 @@ class plugin_fuserfield extends plugin_base {
             if (empty($operator)) {
                 $operator = '~';
             } else if (!in_array($operator, $operators)) {
-                print_error('nosuchoperator');
+                throw new \moodle_exception('nosuchoperator');
             }
             if ($operator == '~') {
                 $replace = " AND " . $field . " LIKE '%" . $filtersearchtext . "%'";

--- a/components/filters/searchtext/plugin.class.php
+++ b/components/filters/searchtext/plugin.class.php
@@ -84,7 +84,7 @@ class plugin_searchtext extends plugin_base{
         if (preg_match("/%%$filterstrmatch:([^%]+)%%/i", $finalelements, $output)) {
             list($field, $operator) = preg_split('/:/', $output[1]);
             if (!in_array($operator, $operators)) {
-                print_error('nosuchoperator');
+                throw new \moodle_exception('nosuchoperator');
             }
             if ($operator == '~') {
                 $replace = " AND " . $field . " LIKE '%" . $filtersearchtext . "%'";

--- a/components/filters/startendtime/plugin.class.php
+++ b/components/filters/startendtime/plugin.class.php
@@ -66,7 +66,7 @@ class plugin_startendtime extends plugin_base {
         if (preg_match("/%%FILTER_STARTTIME:([^%]+)%%/i", $finalelements, $output)) {
             list($field, $operator) = preg_split('/:/', $output[1]);
             if (!in_array($operator, $operators)) {
-                print_error('nosuchoperator');
+                throw new \moodle_exception('nosuchoperator');
             }
             $replace = ' AND '.$field.' '.$operator.' '.$filterstarttime;
             $finalelements = str_replace('%%FILTER_STARTTIME:'.$output[1].'%%', $replace, $finalelements);
@@ -75,7 +75,7 @@ class plugin_startendtime extends plugin_base {
         if (preg_match("/%%FILTER_ENDTIME:([^%]+)%%/i", $finalelements, $output)) {
             list($field, $operator) = preg_split('/:/', $output[1]);
             if (!in_array($operator, $operators)) {
-                print_error('nosuchoperator');
+                throw new \moodle_exception('nosuchoperator');
             }
             $replace = ' AND '.$field.' '.$operator.' '.$filterendtime;
             $finalelements = str_replace('%%FILTER_ENDTIME:'.$output[1].'%%', $replace, $finalelements);

--- a/components/plot/bar/form.php
+++ b/components/plot/bar/form.php
@@ -33,7 +33,7 @@ class bar_form extends moodleform {
             $components = cr_unserialize($this->_customdata['report']->components);
 
             if (!is_array($components) || empty($components['columns']['elements'])) {
-                print_error('nocolumns');
+                throw new \moodle_exception('nocolumns');
             }
 
             $columns = $components['columns']['elements'];

--- a/components/plot/bar/graph.php
+++ b/components/plot/bar/graph.php
@@ -31,13 +31,13 @@ $id = required_param('id', PARAM_ALPHANUM);
 $reportid = required_param('reportid', PARAM_INT);
 
 if (!$report = $DB->get_record('block_configurable_reports', array('id' => $reportid))) {
-    print_error('reportdoesnotexists');
+    throw new \moodle_exception('reportdoesnotexists');
 }
 
 $courseid = $report->courseid;
 
 if (!$course = $DB->get_record('course', array('id' => $courseid))) {
-    print_error('No such course id');
+    throw new \moodle_exception('No such course id');
 }
 
 // Force user login in course (SITE or Course).
@@ -55,7 +55,7 @@ $reportclassname = 'report_'.$report->type;
 $reportclass = new $reportclassname($report);
 
 if (!$reportclass->check_permissions($USER->id, $context)) {
-    print_error("No permissions");
+    throw new \moodle_exception("No permissions");
 } else {
     $components = cr_unserialize($report->components);
     $graphs = $components['plot']['elements'];

--- a/components/plot/line/form.php
+++ b/components/plot/line/form.php
@@ -34,7 +34,7 @@ class line_form extends moodleform {
             $components = cr_unserialize($this->_customdata['report']->components);
 
             if (!is_array($components) || empty($components['columns']['elements'])) {
-                print_error('nocolumns');
+                throw new \moodle_exception('nocolumns');
             }
 
             $columns = $components['columns']['elements'];

--- a/components/plot/line/graph.php
+++ b/components/plot/line/graph.php
@@ -34,13 +34,13 @@ $id = required_param('id', PARAM_ALPHANUM);
 $reportid = required_param('reportid', PARAM_INT);
 
 if (!$report = $DB->get_record('block_configurable_reports', array('id' => $reportid))) {
-    print_error('reportdoesnotexists');
+    throw new \moodle_exception('reportdoesnotexists');
 }
 
 $courseid = $report->courseid;
 
 if (!$course = $DB->get_record('course', array('id' => $courseid))) {
-    print_error('No such course id');
+    throw new \moodle_exception('No such course id');
 }
 
 // Force user login in course (SITE or Course).
@@ -59,7 +59,7 @@ $reportclassname = 'report_'.$report->type;
 $reportclass = new $reportclassname($report);
 
 if (!$reportclass->check_permissions($USER->id, $context)) {
-    print_error("No permissions");
+    throw new \moodle_exception("No permissions");
 } else {
 
     $components = cr_unserialize($report->components);

--- a/components/plot/pie/form.php
+++ b/components/plot/pie/form.php
@@ -34,7 +34,7 @@ class pie_form extends moodleform {
             $components = cr_unserialize($this->_customdata['report']->components);
 
             if (!is_array($components) || empty($components['columns']['elements'])) {
-                print_error('nocolumns');
+                throw new \moodle_exception('nocolumns');
             }
 
             $columns = $components['columns']['elements'];

--- a/components/plot/pie/graph.php
+++ b/components/plot/pie/graph.php
@@ -34,13 +34,13 @@ $id = required_param('id', PARAM_ALPHANUM);
 $reportid = required_param('reportid', PARAM_INT);
 
 if (!$report = $DB->get_record('block_configurable_reports', array('id' => $reportid))) {
-    print_error('reportdoesnotexists');
+    throw new \moodle_exception('reportdoesnotexists');
 }
 
 $courseid = $report->courseid;
 
 if (!$course = $DB->get_record('course', array('id' => $courseid))) {
-    print_error("No such course id");
+    throw new \moodle_exception("No such course id");
 }
 
 // Force user login in course (SITE or Course).
@@ -59,7 +59,7 @@ $reportclassname = 'report_'.$report->type;
 $reportclass = new $reportclassname($report);
 
 if (!$reportclass->check_permissions($USER->id, $context)) {
-    print_error("No permissions");
+    throw new \moodle_exception("No permissions");
 } else {
 
     $components = cr_unserialize($report->components);

--- a/editcomp.php
+++ b/editcomp.php
@@ -34,7 +34,7 @@ $comp = required_param('comp', PARAM_ALPHA);
 $courseid = optional_param('courseid', null, PARAM_INT);
 
 if (!$report = $DB->get_record('block_configurable_reports', ['id' => $id])) {
-    print_error('reportdoesnotexists');
+    throw new \moodle_exception('reportdoesnotexists');
 }
 
 // Ignore report's courseid, If we are running this report on a specific courseid
@@ -44,7 +44,7 @@ if (empty($courseid)) {
 }
 
 if (!$course = $DB->get_record("course", ['id' => $courseid])) {
-    print_error("No such course id");
+    throw new \moodle_exception("No such course id");
 }
 
 // Force user login in course (SITE or Course).
@@ -64,15 +64,15 @@ $PAGE->requires->js('/blocks/configurable_reports/js/configurable_reports.js');
 
 $hasreportscap = has_capability('block/configurable_reports:managereports', $context);
 if (!$hasreportscap && !has_capability('block/configurable_reports:manageownreports', $context)) {
-    print_error('badpermissions');
+    throw new \moodle_exception('badpermissions');
 }
 
 if (!$hasreportscap && $report->ownerid != $USER->id) {
-    print_error('badpermissions');
+    throw new \moodle_exception('badpermissions');
 }
 
 if ($report->type == 'sql' && !block_configurable_reports_can_managesqlreports($context)) {
-    print_error('nosqlpermissions');
+    throw new \moodle_exception('nosqlpermissions');
 }
 
 require_once($CFG->dirroot.'/blocks/configurable_reports/reports/'.$report->type.'/report.class.php');
@@ -81,7 +81,7 @@ $reportclassname = 'report_'.$report->type;
 $reportclass = new $reportclassname($report->id);
 
 if (!in_array($comp, $reportclass->components)) {
-    print_error('badcomponent');
+    throw new \moodle_exception('badcomponent');
 }
 
 $elements = cr_unserialize($report->components);

--- a/editplugin.php
+++ b/editplugin.php
@@ -42,11 +42,11 @@ if (!$pname) {
 }
 
 if (!$report = $DB->get_record('block_configurable_reports', array('id' => $id))) {
-    print_error('reportdoesnotexists');
+    throw new \moodle_exception('reportdoesnotexists');
 }
 
 if (!$course = $DB->get_record("course", ['id' => $report->courseid])) {
-    print_error("No such course id");
+    throw new \moodle_exception("No such course id");
 }
 
 // Force user login in course (SITE or Course).
@@ -60,11 +60,11 @@ if ($course->id == SITEID) {
 
 $hasmanagereportcap = has_capability('block/configurable_reports:managereports', $context);
 if (!$hasmanagereportcap && !has_capability('block/configurable_reports:manageownreports', $context)) {
-    print_error('badpermissions');
+    throw new \moodle_exception('badpermissions');
 }
 
 if (!$hasmanagereportcap && $report->ownerid != $USER->id) {
-    print_error('badpermissions');
+    throw new \moodle_exception('badpermissions');
 }
 
 require_once($CFG->dirroot.'/blocks/configurable_reports/report.class.php');
@@ -74,7 +74,7 @@ $reportclassname = 'report_'.$report->type;
 $reportclass = new $reportclassname($report->id);
 
 if (!in_array($comp, $reportclass->components)) {
-    print_error('badcomponent');
+    throw new \moodle_exception('badcomponent');
 }
 
 $PAGE->set_context($context);
@@ -124,7 +124,7 @@ if (!$cid) {
 }
 
 if (!$plugin || $plugin != $pname) {
-    print_error('nosuchplugin');
+    throw new \moodle_exception('nosuchplugin');
 }
 
 require_once($CFG->dirroot.'/blocks/configurable_reports/plugin.class.php');
@@ -180,7 +180,7 @@ if (isset($pluginclass->form) && $pluginclass->form) {
 
             $report->components = cr_serialize($allelements);
             if (!$DB->update_record('block_configurable_reports', $report)) {
-                print_error('errorsaving');
+                throw new \moodle_exception('errorsaving');
             } else {
                 redirect(new moodle_url('/blocks/configurable_reports/editcomp.php', array('id' => $id, 'comp' => $comp)));
                 exit;
@@ -206,7 +206,7 @@ if (isset($pluginclass->form) && $pluginclass->form) {
             $allelements[$comp]['elements'][] = $cdata;
             $report->components = cr_serialize($allelements, false);
             if (!$DB->update_record('block_configurable_reports', $report)) {
-                print_error('errorsaving');
+                throw new \moodle_exception('errorsaving');
             } else {
                 redirect(new moodle_url('/blocks/configurable_reports/editcomp.php', array('id' => $id, 'comp' => $comp)));
                 exit;
@@ -232,7 +232,7 @@ if (isset($pluginclass->form) && $pluginclass->form) {
     $allelements[$comp]['elements'][] = $cdata;
     $report->components = cr_serialize($allelements);
     if (!$DB->update_record('block_configurable_reports', $report)) {
-        print_error('errorsaving');
+        throw new \moodle_exception('errorsaving');
     } else {
         redirect(new moodle_url('/blocks/configurable_reports/editcomp.php', ['id' => $id, 'comp' => $comp]));
         exit;

--- a/editreport.php
+++ b/editreport.php
@@ -41,7 +41,7 @@ if ($id) {
 }
 
 if (!$course = $DB->get_record('course', ['id' => $courseid]) ) {
-    print_error('nosuchcourseid', 'block_configurable_reports');
+    throw new \moodle_exception('nosuchcourseid', 'block_configurable_reports');
 }
 
 // Force user login in course (SITE or Course).
@@ -55,7 +55,7 @@ if ($course->id == SITEID) {
 
 $hasmanagereportcap = has_capability('block/configurable_reports:managereports', $context);
 if (!$hasmanagereportcap && !has_capability('block/configurable_reports:manageownreports', $context)) {
-    print_error('badpermissions', 'block_configurable_reports');
+    throw new \moodle_exception('badpermissions', 'block_configurable_reports');
 }
 
 $PAGE->set_context($context);
@@ -64,22 +64,22 @@ $PAGE->set_pagelayout('incourse');
 
 if ($id) {
     if (!$report = $DB->get_record('block_configurable_reports', ['id' => $id])) {
-        print_error('reportdoesnotexists', 'block_configurable_reports');
+        throw new \moodle_exception('reportdoesnotexists', 'block_configurable_reports');
     }
 
     if (!$hasmanagereportcap && $report->ownerid != $USER->id) {
-        print_error('badpermissions', 'block_configurable_reports');
+        throw new \moodle_exception('badpermissions', 'block_configurable_reports');
     }
     // Extra check.
     if ($report->type == 'sql' && !block_configurable_reports_can_managesqlreports($context)) {
-        print_error('nosqlpermissions');
+        throw new \moodle_exception('nosqlpermissions');
     }
 
     $title = format_string($report->name);
 
     $courseid = $report->courseid;
     if (!$course = $DB->get_record('course', ['id' => $courseid])) {
-        print_error('nosuchcourseid', 'block_configurable_reports');
+        throw new \moodle_exception('nosuchcourseid', 'block_configurable_reports');
     }
 
     require_once($CFG->dirroot.'/blocks/configurable_reports/report.class.php');
@@ -116,7 +116,7 @@ $PAGE->navbar->add($title);
 if (($show || $hide) && confirm_sesskey()) {
     $visible = ($show) ? 1 : 0;
     if (!$DB->set_field('block_configurable_reports', 'visible', $visible, ['id' => $report->id])) {
-        print_error('cannotupdatereport', 'block_configurable_reports');
+        throw new \moodle_exception('cannotupdatereport', 'block_configurable_reports');
     }
     $action = ($visible) ? 'showed' : 'hidden';
     cr_add_to_log($report->courseid, 'configurable_reports', 'report '.$action, '/block/configurable_reports/editreport.php?id='.$report->id, $report->id);
@@ -131,7 +131,7 @@ if ($duplicate && confirm_sesskey()) {
     $newreport->name = get_string('copyasnoun').' '.$newreport->name;
     $newreport->summary = $newreport->summary;
     if (!$newreportid = $DB->insert_record('block_configurable_reports', $newreport)) {
-        print_error('cannotduplicate', 'block_configurable_reports');
+        throw new \moodle_exception('cannotduplicate', 'block_configurable_reports');
     }
     cr_add_to_log($newreport->courseid, 'configurable_reports', 'report duplicated', '/block/configurable_reports/editreport.php?id='.$newreportid, $id);
     header("Location: $CFG->wwwroot/blocks/configurable_reports/managereport.php?courseid=$courseid");
@@ -226,11 +226,11 @@ if ($editform->is_cancelled()) {
 
         // Extra check.
         if ($data->type == 'sql' && !block_configurable_reports_can_managesqlreports($context)) {
-            print_error('nosqlpermissions');
+            throw new \moodle_exception('nosqlpermissions');
         }
 
         if (!$lastid = $DB->insert_record('block_configurable_reports', $data)) {
-            print_error('errorsavingreport', 'block_configurable_reports');
+            throw new \moodle_exception('errorsavingreport', 'block_configurable_reports');
         } else {
             cr_add_to_log($courseid, 'configurable_reports', 'report created', '/block/configurable_reports/editreport.php?id='.$lastid, $data->name);
             $reportclass = new $reportclassname($lastid);
@@ -242,7 +242,7 @@ if ($editform->is_cancelled()) {
         $data->type = $report->type;
 
         if (!$DB->update_record('block_configurable_reports', $data)) {
-            print_error('errorsavingreport', 'block_configurable_reports');
+            throw new \moodle_exception('errorsavingreport', 'block_configurable_reports');
         } else {
             redirect($CFG->wwwroot.'/blocks/configurable_reports/editcomp.php?id='.$data->id.'&comp='.$reportclass->components[0]);
         }

--- a/export.php
+++ b/export.php
@@ -29,12 +29,12 @@ require_once($CFG->dirroot."/blocks/configurable_reports/locallib.php");
 $id = required_param('id', PARAM_INT);
 
 if (!$report = $DB->get_record('block_configurable_reports', array('id' => $id))) {
-    print_error('reportdoesnotexists', 'block_configurable_reports');
+    throw new \moodle_exception('reportdoesnotexists', 'block_configurable_reports');
 }
 
 
 if (!$course = $DB->get_record('course', array('id' => $report->courseid))) {
-    print_error('nosuchcourseid', 'block_configurable_reports');
+    throw new \moodle_exception('nosuchcourseid', 'block_configurable_reports');
 }
 
 
@@ -50,11 +50,11 @@ if ($course->id == SITEID) {
 $PAGE->set_context($context);
 
 if (!has_capability('block/configurable_reports:managereports', $context) && !(has_capability('block/configurable_reports:manageownreports', $context) && $report->ownerid == $USER->id)) {
-    print_error('badpermissions', 'block_configurable_reports');
+    throw new \moodle_exception('badpermissions', 'block_configurable_reports');
 }
 
 if (!confirm_sesskey()) {
-    print_error('badpermissions', 'block_configurable_reports');
+    throw new \moodle_exception('badpermissions', 'block_configurable_reports');
 }
 
 $downloadfilename = clean_filename(format_string($report->name)).'.xml';
@@ -62,7 +62,7 @@ $downloadfilename = clean_filename(format_string($report->name)).'.xml';
 $version = $DB->get_field('config_plugins', 'value', array('plugin' => 'block_configurable_reports', 'name' => 'version'));
 if (!$version) {
     if (!$version = $DB->get_field('block', 'version', array('name' => 'configurable_reports'))) {
-        print_error('Plugin not found');
+        throw new \moodle_exception('Plugin not found');
     }
 }
 

--- a/managereport.php
+++ b/managereport.php
@@ -30,7 +30,7 @@ $courseid = optional_param('courseid', SITEID, PARAM_INT);
 $importurl = optional_param('importurl', '', PARAM_RAW);
 
 if (! $course = $DB->get_record("course", array('id' => $courseid)) ) {
-    print_error("No such course id");
+    throw new \moodle_exception("No such course id");
 }
 
 // Force user login in course (SITE or Course).
@@ -44,7 +44,7 @@ if ($course->id == SITEID) {
 
 if (!has_capability('block/configurable_reports:managereports', $context) &&
         !has_capability('block/configurable_reports:manageownreports', $context)) {
-    print_error('badpermissions');
+    throw new \moodle_exception('badpermissions');
 }
 
 $PAGE->set_url('/blocks/configurable_reports/managereport.php', array('courseid' => $course->id));
@@ -57,14 +57,14 @@ if ($importurl) {
         $data = json_decode($data);
         $xml = base64_decode($data->content);
     } else {
-        print_error('errorimporting');
+        throw new \moodle_exception('errorimporting');
     }
 
     if (cr_import_xml($xml, $course)) {
         redirect("$CFG->wwwroot/blocks/configurable_reports/managereport.php?courseid={$course->id}",
                     get_string('reportcreated', 'block_configurable_reports'));
     } else {
-        print_error('errorimporting');
+        throw new \moodle_exception('errorimporting');
     }
 }
 
@@ -76,7 +76,7 @@ if ($data = $mform->get_data()) {
             redirect("$CFG->wwwroot/blocks/configurable_reports/managereport.php?courseid={$course->id}",
                     get_string('reportcreated', 'block_configurable_reports'));
         } else {
-            print_error('errorimporting');
+            throw new \moodle_exception('errorimporting');
         }
     }
 }

--- a/send_emails.php
+++ b/send_emails.php
@@ -24,7 +24,7 @@ $context = context_course::instance($COURSE->id);
 $PAGE->set_context($context);
 
 if (!has_capability('block/configurable_reports:managereports', $context) && !has_capability('block/configurable_reports:manageownreports', $context)) {
-    print_error('badpermissions');
+    throw new \moodle_exception('badpermissions');
 }
 
 class sendemail_form extends moodleform {

--- a/viewreport.php
+++ b/viewreport.php
@@ -31,7 +31,7 @@ $format = optional_param('format', '', PARAM_ALPHA);
 $courseid = optional_param('courseid', null, PARAM_INT);
 
 if (!$report = $DB->get_record('block_configurable_reports', ['id' => $id])) {
-    print_error('reportdoesnotexists', 'block_configurable_reports');
+    throw new \moodle_exception('reportdoesnotexists', 'block_configurable_reports');
 }
 
 if ($courseid && $report->global) {
@@ -41,7 +41,7 @@ if ($courseid && $report->global) {
 }
 
 if (!$course = $DB->get_record('course', ['id' => $courseid])) {
-    print_error('No such course id');
+    throw new \moodle_exception('No such course id');
 }
 
 // Force user login in course (SITE or Course).
@@ -60,7 +60,7 @@ $reportclassname = 'report_'.$report->type;
 $reportclass = new $reportclassname($report);
 
 if (!$reportclass->check_permissions($USER->id, $context)) {
-    print_error('badpermissions', 'block_configurable_reports');
+    throw new \moodle_exception('badpermissions', 'block_configurable_reports');
 }
 
 $PAGE->set_context($context);


### PR DESCRIPTION
Since moodle 4.0 the method print_error is deprecated. 
[Here](https://tracker.moodle.org/browse/MDL-71062) is the moodle tracker related.
This PR replace all the occurence of print_error by a moodle_exception.