### PR TITLE
Update evalwise.class.php

### DIFF
--- a/reports/evalwise.class.php
+++ b/reports/evalwise.class.php
@@ -56,11 +56,10 @@ class EvalWise extends EvalMath {
      * pfx
      *
      * @param array|bool $tokens
-     * @param array $vars
+     * @param mixed $vars
      * @return array|false|mixed|null
      */
-    public function pfx($tokens, array $vars = []) {
-
+    public function pfx($tokens, $vars = []) {
         if ($tokens === false) {
             return false;
         }
@@ -68,24 +67,22 @@ class EvalWise extends EvalMath {
         $stack = new EvalMathStack;
 
         foreach ($tokens as $token) {
-
-            // If the token is a function, pop arguments off the stack, hand them to the function, and push the result back on.
+            // If the token is a function, pop arguments off the stack, hand them to the function, and push the result back on
             if (is_array($token)) {
-
                 // It's a function!
                 $fnn = $token['fnn'];
                 $count = $token['argcount'];
 
-                if (in_array($fnn, $this->fb)) { // Built-in function.
+                if (in_array($fnn, $this->fb)) { // Built-in function
                     if (is_null($op1 = $stack->pop())) {
                         return $this->trigger("internal error");
                     }
-                    $fnn = preg_replace("/^arc/", "a", $fnn); // For the 'arc' trig synonyms.
+                    $fnn = preg_replace("/^arc/", "a", $fnn); // For the 'arc' trig synonyms
                     if ($fnn === 'ln') {
                         $fnn = 'log';
                     }
 
-                    // TODO Use the PHP internal function if possible.
+                    // TODO Use the PHP internal function if possible
                     // @codingStandardsIgnoreStart
                     /*
                         evaluate postfix notation
@@ -94,11 +91,11 @@ class EvalWise extends EvalMath {
                         + => | => array_merge
                         - => ^ => array_diff
                      */
-                    eval('$stack->push(' . $fnn . '($op1));'); // Perfectly safe eval().
+                    eval('$stack->push(' . $fnn . '($op1));'); // Perfectly safe eval()
                     // @codingStandardsIgnoreEnd
 
-                } else if (array_key_exists($fnn, $this->fc)) { // Calc emulation function.
-                    // Get args.
+                } else if (array_key_exists($fnn, $this->fc)) { // Calc emulation function
+                    // Get args
                     $args = [];
                     for ($i = $count - 1; $i >= 0; $i--) {
                         if (is_null($args[] = $stack->pop())) {
@@ -110,21 +107,21 @@ class EvalWise extends EvalMath {
                         return $this->trigger("internal error");
                     }
                     $stack->push($res);
-                } else if (array_key_exists($fnn, $this->f)) {
-                    // User function.
-                    // Get args.
+
+                } else if (array_key_exists($fnn, $this->f)) { // User function
+                    // Get args
                     $args = [];
                     for ($i = count($this->f[$fnn]['args']) - 1; $i >= 0; $i--) {
                         if (is_null($args[$this->f[$fnn]['args'][$i]] = $stack->pop())) {
                             return $this->trigger('internal error');
                         }
                     }
-
                     // Yay recursion!
                     $stack->push($this->pfx($this->f[$fnn]['func'], $args));
                 }
+
             } else if (in_array($token, ['+', '-', '*', '/', '^'], true)) {
-                // If the token is a binary operator, pop two values off the stack, do the operation, and push the result back on.
+                // If the token is a binary operator, pop two values off the stack, do the operation, and push the result back on
                 if (is_null($op2 = $stack->pop())) {
                     return $this->trigger('internal error');
                 }
@@ -151,10 +148,10 @@ class EvalWise extends EvalMath {
                 }
 
             } else if ($token === "_") {
-                // If the token is a unary operator, pop one value off the stack, do the operation, and push it back on.
+                // If the token is a unary operator, pop one value off the stack, do the operation, and push it back on
                 $stack->push(-1 * $stack->pop());
             } else {
-                // If the token is a number or variable, push it on the stack.
+                // If the token is a number or variable, push it on the stack
                 if (is_numeric($token)) {
                     $stack->push($token);
                 } else if (array_key_exists($token, $this->v)) {
@@ -166,14 +163,13 @@ class EvalWise extends EvalMath {
                 }
             }
         }
-        // When we're out of tokens, the stack should have a single element, the final result.
+
+        // When we're out of tokens, the stack should have a single element, the final result
         if ($stack->count != 1) {
             return $this->trigger("internal error");
         }
 
         $last = $stack->pop();
-
         return $this->data[$last] ?? false;
     }
-
 }


### PR DESCRIPTION
fix: PHP fatal error in evalwise.class.php method signature

Fixed method signature compatibility issue between EvalWise::pfx and parent class EvalMath::pfx by removing array type hint from $vars parameter.