### PR TITLE
#5 [CONTRIB-9748] prevent the use of the deprecated function get_all_user_name_fields

### DIFF
--- a/components/filters/enrolledstudents/plugin.class.php
+++ b/components/filters/enrolledstudents/plugin.class.php
@@ -124,11 +124,11 @@ class plugin_enrolledstudents extends plugin_base {
                 $nameformat = get_string('fullnamedisplay');
             }
 
-            $sort = implode(',', order_in_string(get_all_user_name_fields(), $nameformat));
+            $sort = implode(',', order_in_string(\core_user\fields::get_name_fields(), $nameformat));
 
             [$usql, $params] = $remotedb->get_in_or_equal($enrolledstudentslist);
             $enrolledstudents =
-                $remotedb->get_records_select('user', "id " . $usql, $params, $sort, 'id,' . get_all_user_name_fields(true));
+                $remotedb->get_records_select('user', "id " . $usql, $params, $sort, 'id' . \core_user\fields::for_name()->get_sql()->selects);
 
             foreach ($enrolledstudents as $c) {
                 $enrolledstudentsoptions[$c->id] = fullname($c);

--- a/components/filters/user/plugin.class.php
+++ b/components/filters/user/plugin.class.php
@@ -117,10 +117,10 @@ class plugin_user extends plugin_base {
                 $nameformat = get_string('fullnamedisplay');
             }
 
-            $sort = implode(',', order_in_string(get_all_user_name_fields(), $nameformat));
+            $sort = implode(',', order_in_string(\core_user\fields::get_name_fields(), $nameformat));
 
             [$usql, $params] = $remotedb->get_in_or_equal($userlist);
-            $users = $remotedb->get_records_select('user', "id " . $usql, $params, $sort, 'id,' . get_all_user_name_fields(true));
+            $users = $remotedb->get_records_select('user', "id " . $usql, $params, $sort, 'id' . \core_user\fields::for_name()->get_sql()->selects);
 
             foreach ($users as $c) {
                 $useroptions[$c->id] = fullname($c);

--- a/components/filters/users/plugin.class.php
+++ b/components/filters/users/plugin.class.php
@@ -118,10 +118,10 @@ class plugin_users extends plugin_base {
                 $nameformat = get_string('fullnamedisplay');
             }
 
-            $sort = implode(',', order_in_string(get_all_user_name_fields(), $nameformat));
+            $sort = implode(',', order_in_string(\core_user\fields::get_name_fields(), $nameformat));
 
             [$usql, $params] = $remotedb->get_in_or_equal($userslist);
-            $users = $remotedb->get_records_select('user', "id " . $usql, $params, $sort, 'id,' . get_all_user_name_fields(true));
+            $users = $remotedb->get_records_select('user', "id " . $usql, $params, $sort, 'id' . \core_user\fields::for_name()->get_sql()->selects);
 
             foreach ($users as $c) {
                 $usersoptions[$c->id] = fullname($c);


### PR DESCRIPTION
Solutions:

- `lib.php`: The deprecated function `get_all_user_name_fields` should be replaced by corresponding functions of the module `\core_user\fields`