### PR TITLE
Fix Undefined property: stdClass::$title notice

### DIFF
--- a/block_configurable_reports.php
+++ b/block_configurable_reports.php
@@ -46,7 +46,12 @@ class block_configurable_reports extends block_list {
     public function specialization(): void {
 
         if ($this->config) {
-            $this->title = $this->config->title ?: get_string('pluginname', 'block_configurable_reports');
+            // Check if the title property exists before accessing it
+            if (property_exists($this->config, 'title')) {
+                $this->title = $this->config->title ? $this->config->title : get_string('pluginname', 'block_configurable_reports');
+            } else {
+                $this->title = get_string('pluginname', 'block_configurable_reports');
+            }
         } else {
             $this->title = get_string('pluginname', 'block_configurable_reports');
             $this->config = new stdClass();


### PR DESCRIPTION
Update the specialization() function to fix the PHP Notice:  Undefined property: stdClass::$title in \blocks\configurable_reports\block_configurable_reports.php on line 42