### PR TITLE
Add new filter for courses, customizable with SQL

### DIFF
--- a/components/filters/coursessql/form.php
+++ b/components/filters/coursessql/form.php
@@ -47,7 +47,7 @@ class coursessql_form extends moodleform {
         $mform->addElement('textarea', 'sql', get_string('coursessql_sql', 'block_configurable_reports'));
         $mform->setType('sql', PARAM_RAW);
         $mform->addHelpButton('sql', 'coursessql_sql', 'block_configurable_reports');
-        $mform->setDefault('sql', 'SELECT * FROM prefix_course WHERE category = 1');
+        $mform->setDefault('sql', 'SELECT * FROM {course} WHERE category = 1');
 
         // Buttons.
         $this->add_action_buttons(true, get_string('add', 'block_configurable_reports'));

--- a/components/filters/coursessql/form.php
+++ b/components/filters/coursessql/form.php
@@ -1,0 +1,56 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Form for coursessql filter
+ *
+ * @copyright  2025 think-modular
+ * @package    block_configurable_reports
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ * @author     Stefan Weber <stefan.weber@think-modular.com>
+ */
+
+defined('MOODLE_INTERNAL') || die;
+
+require_once($CFG->libdir . '/formslib.php');
+
+/**
+ * Class coursessql_form
+ *
+ * @copyright  2025 think-modular
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ * @author     Stefan Weber <stefan.weber@think-modular.com>
+ */
+class coursessql_form extends moodleform {
+
+    /**
+     * Form definition
+     */
+    public function definition(): void {
+        $mform =& $this->_form;
+
+        $mform->addElement('header', 'crformheader', get_string('coursessql', 'block_configurable_reports'), '');
+
+        $mform->addElement('textarea', 'sql', get_string('coursessql_sql', 'block_configurable_reports'));
+        $mform->setType('sql', PARAM_RAW);
+        $mform->addHelpButton('sql', 'coursessql_sql', 'block_configurable_reports');
+        $mform->setDefault('sql', 'SELECT * FROM prefix_course WHERE category = 1');
+
+        // Buttons.
+        $this->add_action_buttons(true, get_string('add', 'block_configurable_reports'));
+    }
+
+}

--- a/components/filters/coursessql/plugin.class.php
+++ b/components/filters/coursessql/plugin.class.php
@@ -1,0 +1,127 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Configurable Reports a Moodle block for creating customizable reports
+ *
+ * @copyright  2025 think-modular
+ * @package    block_configurable_reports
+ * @author     Stefan Weber <stefan.weber@think-modular.com>
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+defined('MOODLE_INTERNAL') || die;
+require_once($CFG->dirroot . '/blocks/configurable_reports/plugin.class.php');
+
+/**
+ * Class plugin_categories
+ *
+ * @package   block_configurable_reports
+ * @author     Stefan Weber <stefan.weber@think-modular.com>
+ */
+class plugin_coursessql extends plugin_base {
+
+    /**
+     * Init
+     *
+     * @return void
+     */
+    public function init(): void {
+        $this->form = true;
+        $this->unique = true;
+        $this->fullname = get_string('filtercoursessql', 'block_configurable_reports');
+        $this->reporttypes = ['courses', 'sql'];
+    }
+
+    /**
+     * Summary
+     *
+     * @param object $data
+     * @return string
+     */
+    public function summary(object $data): string {
+        return get_string('filtercoursessql_summary', 'block_configurable_reports');
+    }
+
+    /**
+     * Execute
+     *
+     * @param string $finalelements
+     * @return array|string|string[]
+     */
+    public function execute($finalelements) {
+
+        $filtercourses = optional_param('filter_courses', 0, PARAM_INT);
+        if (!$filtercourses) {
+            return $finalelements;
+        }
+
+        if ($this->report->type !== 'sql') {
+            return [$filtercourses];
+        }
+
+        if (preg_match("/%%FILTER_COURSES:([^%]+)%%/i", $finalelements, $output)) {
+            $replace = ' AND ' . $output[1] . ' = ' . $filtercourses;
+
+            return str_replace('%%FILTER_COURSES:' . $output[1] . '%%', $replace, $finalelements);
+        }
+
+        return $finalelements;
+    }
+
+    /**
+     * Print filter
+     *
+     * @param MoodleQuickForm $mform
+     * @param bool|object $formdata
+     * @return void
+     */
+    public function print_filter(MoodleQuickForm $mform, $formdata = false): void {
+        global $remotedb;
+
+        $reportclassname = 'report_' . $this->report->type;
+        $reportclass = new $reportclassname($this->report);
+
+        if ($this->report->type !== 'sql') {
+            $components = cr_unserialize($this->report->components);
+            $conditions = $components['conditions'];
+
+            $courselist = $reportclass->elements_by_conditions($conditions);
+        } else {
+            $courselist = array_keys($remotedb->get_records_sql($formdata->sql));
+        }
+
+        $sortedcourseoptions = [];
+        $courseoptions = [];
+        $sortedcourseoptions[0] = get_string('filter_all', 'block_configurable_reports');
+
+        if (!empty($courselist)) {
+            [$usql, $params] = $remotedb->get_in_or_equal($courselist);
+            $courses = $remotedb->get_records_select('course', "id $usql", $params);
+
+            foreach ($courses as $c) {
+                $courseoptions[$c->id] = format_string($c->fullname);
+            }
+
+            asort($courseoptions);
+        }
+
+        $sortedcourseoptions += $courseoptions;
+
+        $mform->addElement('select', 'filter_courses', get_string('course'), $sortedcourseoptions);
+        $mform->setType('filter_courses', PARAM_INT);
+    }
+
+}

--- a/lang/en/block_configurable_reports.php
+++ b/lang/en/block_configurable_reports.php
@@ -113,6 +113,7 @@ $string['value'] = "Value";
 $string['filter'] = "Filter";
 $string['nofilteryet'] = "No filters yet";
 $string['courses'] = "Courses";
+$string['coursessql'] = "Courses (SQL)";
 $string['nofiltersyet'] = "No filters yet";
 $string['filter_all'] = 'All';
 $string['filter_apply'] = 'Apply';
@@ -185,6 +186,8 @@ $string['roleusersn'] = "Number of users with role...";
 $string['coursecategory'] = "Course in category";
 $string['filtercourses'] = "Courses";
 $string['filtercourses_summary'] = "This filter shows a list of courses. Only one course can be selected at the same time";
+$string['filtercoursessql'] = "Courses (SQL)";
+$string['filtercoursessql_summary'] = "This filter shows a list of courses that can be customized via SQL. Only one course can be selected at the same time.";
 $string['roleincourse'] = "User with the selected role/s in the current report course";
 $string['reportscapabilities'] = "Report Capabilities";
 $string['reportscapabilities_summary'] = "Users with the capability moodle/site:viewreports enabled";
@@ -560,6 +563,8 @@ $string['label_help'] = 'Text describing the filter to be displayed on the repor
 $string['idnumber'] = 'ID Number';
 $string['idnumber_help'] = 'Used to differentiate between filters of the same type. Case-sensitive.
 Example usage: %%FILTER_SEARCHTEXT_username:u.username:~%%';
+$string['coursessql_sql'] = 'SQL';
+$string['coursessql_sql_help'] = 'SQL query to retrieve the courses, eg SELECT * FROM prefix_course WHERE category = 1';
 
 // Pie Chart Strings.
 $string['description'] = 'Description';


### PR DESCRIPTION
I added a new filter "coursesql", that lets you limit the courses in the dropdown of the filter via SQL.

It might be easier/better to just add the config form to the existing courses filter instead, let me know what you think :)

<img width="771" height="371" alt="image" src="https://github.com/user-attachments/assets/90cc4c7b-8061-4fc2-91da-fb6c02e05fbe" />

<img width="803" height="331" alt="image" src="https://github.com/user-attachments/assets/bae066e6-ee65-4f6b-bf51-78829f280a4b" />

