### PR TITLE
Add settings form for defaults to startendtime filter

### DIFF
--- a/components/filters/startendtime/plugin.class.php
+++ b/components/filters/startendtime/plugin.class.php
@@ -39,7 +39,7 @@ class plugin_startendtime extends plugin_base {
      * @return void
      */
     public function init(): void {
-        $this->form = false;
+        $this->form = true;
         $this->unique = true;
         $this->fullname = get_string('startendtime', 'block_configurable_reports');
         $this->reporttypes = ['sql', 'timeline', 'users', 'courses'];
@@ -69,11 +69,11 @@ class plugin_startendtime extends plugin_base {
         }
 
         if ($CFG->version < 2011120100) {
-            $filterstarttime = optional_param('filter_starttime', 0, PARAM_RAW);
-            $filterendtime = optional_param('filter_endtime', 0, PARAM_RAW);
+            $filterstarttime = optional_param('filter_start_time', 0, PARAM_RAW);
+            $filterendtime = optional_param('filter_end_time', 0, PARAM_RAW);
         } else {
-            $filterstarttime = optional_param_array('filter_starttime', 0, PARAM_RAW);
-            $filterendtime = optional_param_array('filter_endtime', 0, PARAM_RAW);
+            $filterstarttime = optional_param_array('filter_start_time', 0, PARAM_RAW);
+            $filterendtime = optional_param_array('filter_end_time', 0, PARAM_RAW);
         }
 
         if (!$filterstarttime || !$filterendtime) {
@@ -130,10 +130,22 @@ class plugin_startendtime extends plugin_base {
      */
     public function print_filter(MoodleQuickForm $mform, $formdata = false): void {
 
-        $mform->addElement('date_time_selector', 'filter_starttime', get_string('starttime', 'block_configurable_reports'));
-        $mform->setDefault('filter_starttime', time() - 3600 * 24);
-        $mform->addElement('date_time_selector', 'filter_endtime', get_string('endtime', 'block_configurable_reports'));
-        $mform->setDefault('filter_endtime', time() + 3600 * 24);
+        // Get defaults from settings.
+        $defaultstarttime = time() - 3600 * 24;
+        $defaultendtime = time() + 3600 * 24;
+        if ($formdata) {
+            if ($formdata->set_startdate) {
+                $defaultstarttime = $formdata->startdate ?? $defaultstarttime;
+            }
+            if ($formdata->set_enddate) {
+                $defaultendtime = $formdata->enddate ?? $defaultendtime;
+            }
+        }
+
+        $mform->addElement('date_time_selector', 'filter_start_time', get_string('starttime', 'block_configurable_reports'));
+        $mform->setDefault('filter_start_time', $defaultstarttime);
+        $mform->addElement('date_time_selector', 'filter_end_time', get_string('endtime', 'block_configurable_reports'));
+        $mform->setDefault('filter_end_time', $defaultendtime);
     }
 
 }

--- a/lang/en/block_configurable_reports.php
+++ b/lang/en/block_configurable_reports.php
@@ -560,6 +560,8 @@ $string['label_help'] = 'Text describing the filter to be displayed on the repor
 $string['idnumber'] = 'ID Number';
 $string['idnumber_help'] = 'Used to differentiate between filters of the same type. Case-sensitive.
 Example usage: %%FILTER_SEARCHTEXT_username:u.username:~%%';
+$string['starttime_default'] = 'Set a default value for start time';
+$string['endtime_default'] = 'Set a default value for end time';
 
 // Pie Chart Strings.
 $string['description'] = 'Description';


### PR DESCRIPTION
This adds a setting form for default values to the startendtime filter.

<img width="773" height="349" alt="image" src="https://github.com/user-attachments/assets/798a6ff4-e226-44fa-bc9b-c62f37ebf75f" />


I could not get it to work without changing the form element's names. I don't know what kind of black magic always changed the year for the startdate to set it back 2 years.