### PR TITLE
Fix search text with operator ~ case insensitive for PostgreSQL

### DIFF
--- a/components/filters/fuserfield/plugin.class.php
+++ b/components/filters/fuserfield/plugin.class.php
@@ -235,9 +235,13 @@ class plugin_fuserfield extends plugin_base {
                 throw new moodle_exception('nosuchoperator');
             }
             if ($operator === '~') {
+                global $CFG;
                 // TODO can be improved by more native PDO approach.
                 $searchitem = trim(str_replace("'", "''", $filtersearchtext));
                 $replace = " AND " . $field . " LIKE '%" . $searchitem . "%'";
+                if ($CFG->dbtype == 'pgsql') {
+                    $replace = " AND " . $field . " ILIKE '%" . $searchitem . "%'";
+                }
             } else if ($operator === 'in') {
                 $processeditems = [];
 

--- a/components/filters/searchtext/plugin.class.php
+++ b/components/filters/searchtext/plugin.class.php
@@ -135,8 +135,12 @@ class plugin_searchtext extends plugin_base {
             }
 
             if ($operator === '~') {
+                global $CFG;
                 $searchitem = trim(str_replace("'", "''", $filtersearchtext));
                 $replace = " AND " . $field . " LIKE '%" . $searchitem . "%'";
+                if ($CFG->dbtype == 'pgsql') {
+                    $replace = " AND " . $field . " ILIKE '%" . $searchitem . "%'";
+                }
             } else if ($operator === 'in') {
                 $processeditems = [];
                 // Accept comma-separated values, allowing for '\,' as a literal comma.

--- a/version.php
+++ b/version.php
@@ -27,7 +27,7 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version = 2024051300;
+$plugin->version = 2026030400;
 $plugin->requires = 2017111300;
 $plugin->maturity = MATURITY_STABLE;
 $plugin->release = '4.1.0';


### PR DESCRIPTION
For Maria DB and MySQL, the search text and user field functions are returning case-insensitive results with the operator ~, but over Postgres, the case-insensitivity happens with the usage of ILIKE, and for the current code, it is not happening. 
This patch checks if the DB type is Postgres and adds the usage of ILIKE for the operator ~.

Kind regards,
Rodrigo Mady